### PR TITLE
Fix ArrayQueue destructor

### DIFF
--- a/cpp/ArrayQueue.h
+++ b/cpp/ArrayQueue.h
@@ -34,7 +34,6 @@ ArrayQueue<T>::ArrayQueue() : a(1) {
 
 template<class T>
 ArrayQueue<T>::~ArrayQueue() {
-	delete a;
 }
 
 template<class T>


### PR DESCRIPTION
The member `a` is not dynamically allocated, so doesn't need to be deleted. Removing the `delete` fixes a compilation error. (The other array-based implementations seem not to have this problem.) Thanks to my students who discovered this!